### PR TITLE
Fix: Accidental item duplication on drop

### DIFF
--- a/src/components/vddl-draggable.vue
+++ b/src/components/vddl-draggable.vue
@@ -77,14 +77,18 @@ export default {
       switch (dropEffect) {
         case "move":
           if (typeof(this.moved) === 'function') {
-            this.moved({
-              index: this.index,
-              list: this.wrapper,
-              event: event.target,
-              draggable: this.draggable,
+            this.$nextTick(() => {
+              this.moved({
+                index: this.index,
+                list: this.wrapper,
+                event: event.target,
+                draggable: this.draggable,
+              });
             });
           } else {
-            this.wrapper.splice(this.index, 1);
+            this.$nextTick(() => {
+              this.wrapper.splice(this.index, 1);
+            });
           }
           break;
         case "copy":


### PR DESCRIPTION
The item was being spliced out from the list before the index had a chance to update to adjust to the new list. By waiting for the next tick in Vue we can  make sure that no item will be spliced before the list has fully updated and the index has been changed to the correct one.

This bug was introduced with Vue 2.5.0.
This pull request solves #4 