### PR TITLE
fix: safari copy item issue

### DIFF
--- a/src/components/vddl-draggable.vue
+++ b/src/components/vddl-draggable.vue
@@ -44,9 +44,6 @@ export default {
       // Serialize the data associated with this element. IE only supports the Text drag type
       event.dataTransfer.setData("Text", draggable);
 
-      // Only allow actions specified in effect-allowed attribute
-      event.dataTransfer.effectAllowed = this.effectAllowed || "move";
-
       // Add CSS classes. IE9 not support 'classList'
       this.$el.className = this.$el.className.trim() + " vddl-dragging";
       setTimeout(() => {
@@ -54,7 +51,7 @@ export default {
       }, 0);
 
       // Workarounds for stupid browsers, see description below
-      this.vddlDropEffectWorkaround.dropEffect = "none";
+      this.vddlDropEffectWorkaround.dropEffect = this.effectAllowed || "move";
       this.vddlDragTypeWorkaround.isDragging = true;
 
       // Save type of item in global state. Usually, this would go into the dataTransfer

--- a/src/components/vddl-list.vue
+++ b/src/components/vddl-list.vue
@@ -119,17 +119,12 @@ export default {
       }
       this.invokeCallback('inserted', event, index, transferredObject);
 
-      // In Chrome on Windows the dropEffect will always be none...
-      // We have to determine the actual effect manually from the allowed effects
-      if (event.dataTransfer.dropEffect === "none") {
-        if (event.dataTransfer.effectAllowed === "copy" ||
-            event.dataTransfer.effectAllowed === "move") {
-          this.vddlDropEffectWorkaround.dropEffect = event.dataTransfer.effectAllowed;
-        } else {
-          this.vddlDropEffectWorkaround.dropEffect = event.ctrlKey ? "copy" : "move";
-        }
-      } else {
-        this.vddlDropEffectWorkaround.dropEffect = event.dataTransfer.dropEffect;
+      // As effectAllowed & dropEffect event properties wired behavior
+      // We have to determine the actual effect manually from the `vddlDropEffectWorkaround.dropEffect`
+      // Which is set in `handleDragstart` method
+      var dropEffect = this.vddlDropEffectWorkaround.dropEffect;
+      if (dropEffect !== "copy" && dropEffect !== "move") {
+        this.vddlDropEffectWorkaround.dropEffect = event.ctrlKey ? "copy" : "move";
       }
 
       // Clean up
@@ -254,4 +249,3 @@ export default {
   },
 };
 </script>
-


### PR DESCRIPTION
For `effectAllowed` we can not rely on drag event properties since different browsers give different results. In Safari (MacOS) I always received effectAllowed = 'all', does not matter I assign the property (`effect-allowed`) to `vddl-draggable` or not. It always triggers move effect. So what I did here is except relying on browser's event, I made the tweak on existing prototype object (`vddlDropEffectWorkaround.dropEffect`) that you created for wired browser behavior. It solves my issue.

Please accept my pull request, if you don't, tell me what else we can do to solve this quirk. 